### PR TITLE
Update number serialization in data helper

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,6 @@
+### Kustomer Integration for Magento Update History
+
+#### 1.1.0
+- Updated order normalize function to coerce values to double-precise floats instead of strings
+- Removed automatica insertion of store currency symbol as part of the above change
+- Added this update history document

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -125,9 +125,9 @@ class Data extends AbstractHelper
      * @param float $value
      * @return string
      */
-    public function normalizeCurrencyValue($value)
+    public function normalizeNumericValue($value)
     {
-        return $this->pricingHelper->currency($value, true, false);
+        return round((float)$value, 2);
     }
 
     /**
@@ -167,11 +167,11 @@ class Data extends AbstractHelper
             'state' => $order->getState(),
             'status' => $order->getStatus(),
             'currency_code' => $order->getOrderCurrencyCode(),
-            'subtotal' => $this->normalizeCurrencyValue($order->getSubtotal()),
-            'total_due' => $this->normalizeCurrencyValue($order->getTotalDue()),
-            'total_discount' => $this->normalizeCurrencyValue($order->getDiscountAmount()),
-            'total_paid' => $this->normalizeCurrencyValue($order->getTotalPaid()),
-            'total_refunded' => $this->normalizeCurrencyValue($order->getTotalRefunded()),
+            'subtotal' => $this->normalizeNumericValue($order->getSubtotal()),
+            'total_due' => $this->normalizeNumericValue($order->getTotalDue()),
+            'total_discount' => $this->normalizeNumericValue($order->getDiscountAmount()),
+            'total_paid' => $this->normalizeNumericValue($order->getTotalPaid()),
+            'total_refunded' => $this->normalizeNumericValue($order->getTotalRefunded()),
             'extension_attributes' => $order->getExtensionAttributes()
         );
 
@@ -258,9 +258,9 @@ class Data extends AbstractHelper
                 'sku' => $item->getSku(),
                 'product_id' => $item->getProductId(),
                 'quantity' => $item->getQtyOrdered(),
-                'price' => $this->normalizeCurrencyValue($item->getPrice()),
-                'discount' => $this->normalizeCurrencyValue($item->getDiscountAmount()),
-                'total' => $this->normalizeCurrencyValue($item->getRowTotal()),
+                'price' => $this->normalizeNumericValue($item->getPrice()),
+                'discount' => $this->normalizeNumericValue($item->getDiscountAmount()),
+                'total' => $this->normalizeNumericValue($item->getRowTotal()),
             ));
         }
         return $normalized;
@@ -276,7 +276,7 @@ class Data extends AbstractHelper
             array(
                 'description' => $shipping->getShippingDescription(),
                 'method' => $shipping->getShippingMethod(),
-                'amount' => $this->normalizeCurrencyValue($shipping->getShippingAmount()),
+                'amount' => $this->normalizeNumericValue($shipping->getShippingAmount()),
             ),
             $this->normalizeAddress($shipping)
         );

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -109,6 +109,9 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $billing
     )
     {
+        $prec = ini_get('serialize_precision');
+        ini_set('serialize_precision', 3);
+
         $itemMock = $this->getMockBuilder(\Magento\Sales\Api\Data\OrderItemInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -375,6 +378,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->model->normalizeOrder($order);
         $this->assertEquals($fixture, $result);
+        ini_set('serialize_precision', $prec);
     }
 
     public function dataProviderNormalizeOrderReturnArray()
@@ -390,23 +394,23 @@ class DataTest extends \PHPUnit\Framework\TestCase
                             'sku' => 'foobar123',
                             'product_id' => 44,
                             'quantity' => 1,
-                            'price' => '$4.99',
-                            'discount' => '$0.00',
-                            'total' => '$4.99'
+                            'price' => 4.99,
+                            'discount' => 0.00,
+                            'total' => 4.99
                         ]
                     ],
                     'currency_code' => 'USD',
-                    'subtotal' => '$4.99',
-                    'total_due' => '$6.32',
-                    'total_discount' => '$0.00',
-                    'total_paid' => '$0.00',
-                    'total_refunded' => '$0.00',
+                    'subtotal' => 4.99,
+                    'total_due' => 6.32,
+                    'total_discount' => 0.0,
+                    'total_paid' => 0.0,
+                    'total_refunded' => 0.0,
                     'extension_attributes' => [],
                     'state' => 'new',
                     'status' => 'pending',
                     'shipping_description' => 'UPS Next Day Air',
                     'shipping_method' => 'ups_1D',
-                    'shipping_amount' => '$1.33',
+                    'shipping_amount' => 1.33,
                     'shipping_street' => '5808 Lake Washington Blvd Suite 700',
                     'shipping_state' => 'Washington',
                     'shipping_city' => 'Kirkland',

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kustomer/kustomer-integration",
   "description": "Integrate Magento eCommerce site with Kustomer service",
   "type": "magento2-module",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
- Updates order normalize function to coerce values to double-precise floats instead of strings
- Removed automatic insertion of store currency symbol as part of the above change
- Added update history document

cc @kustomer/backend-devs 