### PR TITLE
Remove dependence on Magento Framework Curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexcheng/magento2:2.2.2-integrator
+FROM alexcheng/magento2:2.1-developer
 
 ADD . app/code/Kustomer/KustomerIntegration
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ### Kustomer Integration for Magento Update History
 
+#### 1.1.3
+
+- Remove use of `\Magento\Framework\HTTP\Client\Curl`
+
 #### 1.1.2
 
 - Minor internal changes that should have no functional impact

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -40,11 +40,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
     protected $pricingHelper;
 
     /**
-     * @var \Magento\Framework\HTTP\Client\Curl | \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $curl;
-
-    /**
      * @var \Psr\Log\LoggerInterface | \PHPUnit_Framework_MockObject_MockObject
      */
     protected $logger;
@@ -74,10 +69,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->curl = $this->getMockBuilder(\Magento\Framework\HTTP\Client\Curl::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->logger = $this->getMockBuilder(\Psr\Log\LoggerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -88,7 +79,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             $this->customerRepository,
             $this->quoteRepository,
             $this->pricingHelper,
-            $this->curl,
             $this->logger
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kustomer/kustomer-integration",
   "description": "Integrate Magento eCommerce site with Kustomer service",
   "type": "magento2-module",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Kustomer_KustomerIntegration" setup_version="1.1.2">
+    <module name="Kustomer_KustomerIntegration" setup_version="1.1.3">
         <sequence>
             <module name="Magento_Store"/>
         </sequence>


### PR DESCRIPTION
Changes library used to execute API requests to Kustomer from `\Magento\Framework\HTTP\Client\Curl` to php's built-in `curl` wrapper.

This is to avoid a compatibility issue between Magento 2.1 and 2.2, where those classes have a different implementation. The 2.2 version can handle JSON bodies, whereas the 2.1 version can only accept multipart form fields.

cc @kustomer/backend-devs 