### PR TITLE
Add increment id to order output

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -157,6 +157,7 @@ class Data extends AbstractHelper
         $paymentData = $quote->getPayment();
         $orderArray = array(
             'id' => $order->getEntityId(),
+            'increment_id' => $order->getIncrementId(),
             'items' => $this->normalizeOrderItems($order->getItems()),
             'state' => $order->getState(),
             'status' => $order->getStatus(),

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -186,6 +186,11 @@ class DataTest extends \PHPUnit\Framework\TestCase
 
         $order
             ->expects($this->once())
+            ->method('getIncrementId')
+            ->willReturn($fixture['increment_id']);
+
+        $order
+            ->expects($this->once())
             ->method('getEntityId')
             ->willReturn($fixture['id']);
 
@@ -378,6 +383,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             [
                 'fixture' => [
                     'id' => 3,
+                    'increment_id' => 1249920111,
                     'items' => [
                         [
                             'name' => 'foo',

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kustomer/kustomer-integration",
   "description": "Integrate Magento eCommerce site with Kustomer service",
   "type": "magento2-module",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Kustomer_KustomerIntegration" setup_version="1.1.3">
+    <module name="Kustomer_KustomerIntegration" setup_version="1.1.4">
         <sequence>
             <module name="Magento_Store"/>
         </sequence>


### PR DESCRIPTION
This PR adds increment ID to the `DataHelper#normalizeOrder` method. This is so users can use the human-readable order information when dealing with customers instead of the `entity_id`, which is not as public-facing.

cc @kustomer/backend-devs 