### PR TITLE
Support Multiple Kustomer Pods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,15 @@
 ### Kustomer Integration for Magento Update History
 
+#### 1.1.5
+
+- Add required org name setting
+- Adjusts base url (api.kustomerapp.com) to use subdomain (org-name.api.kustomerapp.com) to support new Kustomer regions
+
+
+#### 1.1.4
+
+- Add increment_id to event payload in addition to entity_id
+
 #### 1.1.3
 
 - Remove use of `\Magento\Framework\HTTP\Client\Curl`

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -21,6 +21,7 @@ class Data extends AbstractHelper
     const XML_PATH_EVENT = 'kustomer/event/';
     const XML_PATH_ENABLED = 'kustomer/integration/active';
     const XML_PATH_API_KEY = 'kustomer/integration/api_key';
+    const XML_PATH_ORG_NAME = 'kustomer/integration/org_name';
     const API_ENDPOINT = 'events';
     const ACCEPT_HEADER = 'application/json';
     const KUSTOMER_DOMAIN = 'https://api.kustomerapp.com';
@@ -53,16 +54,24 @@ class Data extends AbstractHelper
     }
 
     /**
+     * @param string $subdomain
      * @return string
      */
-    public function getKustomerUri()
+    public function getKustomerUri($subdomain)
     {
         $domain = getenv('KUSTOMER_API_DOMAIN');
+
         if (empty($domain))
         {
-            return self::KUSTOMER_DOMAIN;
+            $domain = self::KUSTOMER_DOMAIN;
         }
-        return $domain;
+
+        $domainParts = explode("://", $domain, 2);
+
+        $protocol = $domainParts[0];
+        $host = $domainParts[1];
+
+        return "$protocol://$subdomain.$host";
     }
 
     /**
@@ -312,17 +321,28 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param CustomerInterface $customer
+     * @param Store|null $store
      * @return string
      */
-    public function getUriByCustomer($customer)
+    public function getKustomerOrgName($store = null)
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_ORG_NAME, ScopeInterface::SCOPE_STORE, $store);
+    }
+
+    /**
+     * @param CustomerInterface $customer
+     * @param Store|null $store
+     * @return string
+     */
+    public function getUriByCustomer($customer, $store = null)
     {
         if (is_array($customer) && $customer['guest']) {
             $customerId = 'guest';
         } else {
             $customerId = $customer->getId();
         }
-        $baseUri = $this->getKustomerUri().self::BASE_KUSTOMER_URI;
+        $subdomain = $this->getKustomerOrgName($store);
+        $baseUri = $this->getKustomerUri($subdomain).self::BASE_KUSTOMER_URI;
         return $baseUri.$customerId.'/'.self::API_ENDPOINT;
     }
 

--- a/Observer/KustomerEventObserver.php
+++ b/Observer/KustomerEventObserver.php
@@ -83,8 +83,6 @@ abstract class KustomerEventObserver implements ObserverInterface
      */
     protected function __publish($eventName, $dataType, $data, $customer, $store = null)
     {
-        $uri = $this->__helperData->getUriByCustomer($customer);
-
         if (is_int($store) || is_string($store)) {
             $store = $this->__storeRepository->getStore($store);
         } elseif (!is_array($customer) && empty($store))
@@ -102,6 +100,8 @@ abstract class KustomerEventObserver implements ObserverInterface
                 'data' => $data
             ]
         ]);
+
+        $uri = $this->__helperData->getUriByCustomer($customer, $store->getId());
 
         /** @var Event $event */
         $event = $this->eventFactory->create();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kustomer/kustomer-integration",
   "description": "Integrate Magento eCommerce site with Kustomer service",
   "type": "magento2-module",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,6 +14,12 @@
                 <field id="api_key" translate="label" type="text" sortOrder="11" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Kustomer API Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <validate>required-entry</validate>
+                </field>
+                <field id="org_name" translate="label" type="text" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Kustomer Organization Name</label>
+                    <comment>This is your subdomain for Kustomer. For example, if you typically go to "org-name.kustomerapp.com", enter "org-name" in this field.</comment>
+                    <validate>required-entry</validate>
                 </field>
             </group>
             <group id="event" translate="label" type="text" sortOrder="21" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Kustomer_KustomerIntegration" setup_version="1.1.4">
+    <module name="Kustomer_KustomerIntegration" setup_version="1.1.5">
         <sequence>
             <module name="Magento_Store"/>
         </sequence>


### PR DESCRIPTION
This PR enables support for Kustomer's EU pod in addition to the existing US pod.

This is done by adding an `org_name` parameter to the Magento system options and using that parameter as the subdomain for requests.

Since subdomain-scoped requests will leverage DNS to communicate with the correct Kustomer pod, this will work for any new pod added in the future.

New Setting:
![](https://cl.ly/2c617b4a8ae3/Image%202019-12-10%20at%207.31.37%20AM.png)

@kustomer/backend-devs please review